### PR TITLE
Add description to options

### DIFF
--- a/packages/json-schemas/schemas/template/template.json
+++ b/packages/json-schemas/schemas/template/template.json
@@ -11,6 +11,12 @@
     "options": {
       "type": "object",
       "description": "The options for the template.",
+      "propertyNames": {
+        "type": "string",
+        "description": "The name of the option.",
+        "pattern": "^[a-zA-Z0-9_]+$",
+        "minLength": 1
+      },
       "additionalProperties": {
         "type": "object",
         "required": ["type"],
@@ -31,7 +37,13 @@
               "default": {
                 "type": "string",
                 "description": "The default value for the reference.",
-                "examples": ["variable", "projectName"]
+                "examples": ["projectName"]
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the option.",
+                "minLength": 1,
+                "examples": ["The variable to store the result of the action."]
               }
             },
             "additionalProperties": false
@@ -54,6 +66,12 @@
               "default": {
                 "type": "string",
                 "description": "The default value for the option."
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the option.",
+                "minLength": 1,
+                "examples": ["The name of the project."]
               }
             },
             "additionalProperties": false
@@ -68,6 +86,12 @@
               "default": {
                 "type": "number",
                 "description": "The default value for the option."
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the option.",
+                "minLength": 1,
+                "examples": ["The default timeout."]
               }
             },
             "additionalProperties": false
@@ -82,6 +106,12 @@
               "default": {
                 "type": "boolean",
                 "description": "The default value for the option."
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the option.",
+                "minLength": 1,
+                "examples": ["Whether to enable the feature."]
               }
             },
             "additionalProperties": false
@@ -97,6 +127,12 @@
                 "type": "array",
                 "description": "The default value for the option.",
                 "items": {}
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the option.",
+                "minLength": 1,
+                "examples": ["The list of items."]
               }
             },
             "additionalProperties": false
@@ -112,6 +148,12 @@
                 "type": "object",
                 "description": "The default value for the option.",
                 "additionalProperties": true
+              },
+              "description": {
+                "type": "string",
+                "description": "The description of the option.",
+                "minLength": 1,
+                "examples": ["The configuration object serialized as JSON."]
               }
             },
             "additionalProperties": false

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/template-invalid-properties.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/template-invalid-properties.json
@@ -9,30 +9,37 @@
         "type": "string",
         "choices": [],
         "default": null,
+        "description": "",
         "extra": true
       },
       "reference": {
         "type": "reference",
         "default": null,
+        "description": "",
         "extra": true
       },
       "number": {
         "type": "number",
         "default": null,
+        "description": "",
         "extra": true
       },
       "boolean": {
         "type": "boolean",
         "default": null,
+        "description": "",
         "extra": true
       },
       "array": {
         "type": "array",
-        "default": null
+        "default": null,
+        "description": "",
+        "extra": true
       },
       "object": {
         "type": "object",
         "default": null,
+        "description": "",
         "extra": true
       }
     },
@@ -75,6 +82,15 @@
         "type": "string"
       },
       "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/default/type"
+    },
+    {
+      "instancePath": "/options/string/description",
+      "keyword": "minLength",
+      "message": "must NOT have fewer than 1 characters",
+      "params": {
+        "limit": 1
+      },
+      "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/description/minLength"
     },
     {
       "instancePath": "/options/string/default",
@@ -138,6 +154,15 @@
         "type": "string"
       },
       "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/default/type"
+    },
+    {
+      "instancePath": "/options/reference/description",
+      "keyword": "minLength",
+      "message": "must NOT have fewer than 1 characters",
+      "params": {
+        "limit": 1
+      },
+      "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/description/minLength"
     },
     {
       "instancePath": "/options/reference/type",
@@ -221,6 +246,15 @@
       "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/default/type"
     },
     {
+      "instancePath": "/options/number/description",
+      "keyword": "minLength",
+      "message": "must NOT have fewer than 1 characters",
+      "params": {
+        "limit": 1
+      },
+      "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/description/minLength"
+    },
+    {
       "instancePath": "/options/number/default",
       "keyword": "type",
       "message": "must be number",
@@ -293,6 +327,15 @@
       "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/default/type"
     },
     {
+      "instancePath": "/options/boolean/description",
+      "keyword": "minLength",
+      "message": "must NOT have fewer than 1 characters",
+      "params": {
+        "limit": 1
+      },
+      "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/description/minLength"
+    },
+    {
       "instancePath": "/options/boolean/default",
       "keyword": "type",
       "message": "must be number",
@@ -338,6 +381,15 @@
       "schemaPath": "#/properties/options/additionalProperties/oneOf"
     },
     {
+      "instancePath": "/options/array",
+      "keyword": "additionalProperties",
+      "message": "must NOT have additional properties",
+      "params": {
+        "additionalProperty": "extra"
+      },
+      "schemaPath": "#/properties/options/additionalProperties/oneOf/0/additionalProperties"
+    },
+    {
       "instancePath": "/options/array/type",
       "keyword": "const",
       "message": "must be equal to constant",
@@ -354,6 +406,15 @@
         "type": "string"
       },
       "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/default/type"
+    },
+    {
+      "instancePath": "/options/array/description",
+      "keyword": "minLength",
+      "message": "must NOT have fewer than 1 characters",
+      "params": {
+        "limit": 1
+      },
+      "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/description/minLength"
     },
     {
       "instancePath": "/options/array/default",
@@ -426,6 +487,15 @@
         "type": "string"
       },
       "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/default/type"
+    },
+    {
+      "instancePath": "/options/object/description",
+      "keyword": "minLength",
+      "message": "must NOT have fewer than 1 characters",
+      "params": {
+        "limit": 1
+      },
+      "schemaPath": "#/properties/options/additionalProperties/oneOf/0/properties/description/minLength"
     },
     {
       "instancePath": "/options/object/default",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/template-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/template-complete.json
@@ -10,36 +10,60 @@
       "license": "MIT"
     },
     "options": {
-        "string": {
-            "type": "string",
-            "choices": ["a", "b", "c"],
-            "default": "default value"
-        },
-        "reference": {
-          "type": "reference",
-          "default": "ref"
-        },
-        "number": {
-            "type": "number",
-            "default": 42
-        },
-        "boolean": {
-            "type": "boolean",
-            "default": true
-        },
-        "array": {
-            "type": "array",
-            "default": ["string", 42, true, null, {}, []]
-        },
-        "object": {
-            "type": "object",
-            "default": {
-                "string": "default value",
-                "number": 42,
-                "boolean": true,
-                "array": ["string", 42, true, null, {}, []]
-            }
+      "string": {
+        "type": "string",
+        "description": "description of the option",
+        "choices": [
+          "a",
+          "b",
+          "c"
+        ],
+        "default": "a"
+      },
+      "reference": {
+        "type": "reference",
+        "description": "description of the option",
+        "default": "ref"
+      },
+      "number": {
+        "type": "number",
+        "description": "description of the option",
+        "default": 42
+      },
+      "boolean": {
+        "type": "boolean",
+        "description": "description of the option",
+        "default": true
+      },
+      "array": {
+        "type": "array",
+        "description": "description of the option",
+        "default": [
+          "string",
+          42,
+          true,
+          null,
+          {},
+          []
+        ]
+      },
+      "object": {
+        "type": "object",
+        "description": "description of the option",
+        "default": {
+          "string": "default value",
+          "number": 42,
+          "boolean": true,
+          "array": [
+            "string",
+            42,
+            true,
+            null,
+            {},
+            []
+          ]
         }
+      }
     },
     "actions": [
       {
@@ -105,7 +129,9 @@
       },
       {
         "name": "format-code",
-        "files": ["src/index.js"]
+        "files": [
+          "src/index.js"
+        ]
       },
       {
         "name": "import",


### PR DESCRIPTION
## Summary
Add the missing description property to the template options.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings