### PR TITLE
Fix create resource schema

### DIFF
--- a/packages/json-schemas/schemas/template/action/create-resource.json
+++ b/packages/json-schemas/schemas/template/action/create-resource.json
@@ -94,6 +94,7 @@
             "additionalProperties": false
           },
           "propertyNames": {
+            "type": "string",
             "pattern": "^[a-z-A-Z]+(-?[a-z-A-Z0-9]+)*$",
             "minLength": 1,
             "description": "The ID of the component.",
@@ -412,12 +413,13 @@
           "type": "object",
           "description": "A map of experience indexes to variable names.",
           "propertyNames": {
+            "type": "string",
             "description": "The index of the experience in the list.",
             "pattern": "^[0-9]+$",
             "minLength": 1,
             "examples": [
-              0,
-              1
+              "0",
+              "1"
             ]
           },
           "additionalProperties": {


### PR DESCRIPTION
## Summary

Some property name schemas are missing the `type` field, preventing the transformer from enabling interpolation.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings