### PR TITLE
Add standalone action schema

### DIFF
--- a/.github/workflows/deploy-schemas.yaml
+++ b/.github/workflows/deploy-schemas.yaml
@@ -28,7 +28,9 @@ jobs:
           mkdir -p build/json-schemas
           packages/json-schemas/bin/bundle-schema.ts packages/json-schemas/schemas/event/web-event.json build/json-schemas/web-event.json
           packages/json-schemas/bin/bundle-schema.ts packages/json-schemas/schemas/template/template.json build/json-schemas/template.json
+          packages/json-schemas/bin/bundle-schema.ts packages/json-schemas/schemas/template/action.json build/json-schemas/action.json
           packages/json-schemas/bin/process-template-schema.ts build/json-schemas/template.json build/json-schemas/template.json
+          packages/json-schemas/bin/process-template-schema.ts build/json-schemas/action.json build/json-schemas/action.json
           cp packages/json-schemas/schemas/content.json build/json-schemas/content.json
           cp packages/json-schemas/schemas/content-schema.json build/json-schemas/content-schema.json
           cp packages/json-schemas/schemas/project.json build/json-schemas/project.json

--- a/packages/json-schemas/schemas/template/action.json
+++ b/packages/json-schemas/schemas/template/action.json
@@ -73,6 +73,9 @@
     },
     {
       "$ref": "./action/test.json"
+    },
+    {
+      "$ref": "./action/try.json"
     }
   ]
 }

--- a/packages/json-schemas/schemas/template/action/add-component.json
+++ b/packages/json-schemas/schemas/template/action/add-component.json
@@ -5,6 +5,9 @@
   "description": "Adds a component to the project.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "Tha name of the action.",

--- a/packages/json-schemas/schemas/template/action/add-dependency.json
+++ b/packages/json-schemas/schemas/template/action/add-dependency.json
@@ -5,6 +5,9 @@
   "description": "Adds dependencies to the project.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/add-slot.json
+++ b/packages/json-schemas/schemas/template/action/add-slot.json
@@ -5,6 +5,9 @@
   "description": "Adds a slot to the project.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "Tha name of the action.",

--- a/packages/json-schemas/schemas/template/action/change-directory.json
+++ b/packages/json-schemas/schemas/template/action/change-directory.json
@@ -5,6 +5,9 @@
   "description": "Changes the working directory.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/check-dependency.json
+++ b/packages/json-schemas/schemas/template/action/check-dependency.json
@@ -5,6 +5,9 @@
   "description": "Checks if specific dependencies are installed and optionally stores the result in variables.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/create-resource.json
+++ b/packages/json-schemas/schemas/template/action/create-resource.json
@@ -5,6 +5,9 @@
   "description": "Creates resources such as audiences, components, slots, and experiences.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/define.json
+++ b/packages/json-schemas/schemas/template/action/define.json
@@ -5,6 +5,9 @@
   "description": "Defines variables to be used in the template.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/download.json
+++ b/packages/json-schemas/schemas/template/action/download.json
@@ -5,6 +5,9 @@
   "description": "Downloads files from a remote source into a local directory.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/execute-package.json
+++ b/packages/json-schemas/schemas/template/action/execute-package.json
@@ -5,6 +5,9 @@
   "description": "Executes a package using a runner, optionally handling interactive prompts.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/fail.json
+++ b/packages/json-schemas/schemas/template/action/fail.json
@@ -5,6 +5,9 @@
   "description": "Fails the execution with a custom message and optional suggestions or links.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/format-code.json
+++ b/packages/json-schemas/schemas/template/action/format-code.json
@@ -5,6 +5,9 @@
   "description": "Formats code using the project's configured formatter.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/import.json
+++ b/packages/json-schemas/schemas/template/action/import.json
@@ -5,6 +5,9 @@
   "description": "Imports and executes another template.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/initialize.json
+++ b/packages/json-schemas/schemas/template/action/initialize.json
@@ -5,6 +5,9 @@
   "description": "Initializes a Croct project in the current directory.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/locate-file.json
+++ b/packages/json-schemas/schemas/template/action/locate-file.json
@@ -5,6 +5,9 @@
   "description": "Searches for files under a directory path based on a specified pattern.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/open-link.json
+++ b/packages/json-schemas/schemas/template/action/open-link.json
@@ -5,6 +5,9 @@
   "description": "Opens a URL in the user's default browser.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/print.json
+++ b/packages/json-schemas/schemas/template/action/print.json
@@ -5,6 +5,9 @@
   "description": "Prints a message to the console with optional semantic styling and title.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/prompt-choice.json
+++ b/packages/json-schemas/schemas/template/action/prompt-choice.json
@@ -5,6 +5,9 @@
   "type": "object",
   "description": "Asks the user to select one option from a list.",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/prompt-confirmation.json
+++ b/packages/json-schemas/schemas/template/action/prompt-confirmation.json
@@ -5,6 +5,9 @@
   "type": "object",
   "description": "Asks the user to confirm (yes/no).",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "const": "prompt",

--- a/packages/json-schemas/schemas/template/action/prompt-keypress.json
+++ b/packages/json-schemas/schemas/template/action/prompt-keypress.json
@@ -5,6 +5,9 @@
   "type": "object",
   "description": "Waits for a specific keypress from the user.",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/prompt-multi-choice.json
+++ b/packages/json-schemas/schemas/template/action/prompt-multi-choice.json
@@ -5,6 +5,9 @@
   "type": "object",
   "description": "Asks the user to select multiple options from a list.",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/prompt-text.json
+++ b/packages/json-schemas/schemas/template/action/prompt-text.json
@@ -5,6 +5,9 @@
   "type": "object",
   "description": "Prompts the user for free-form text input.",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/repeat.json
+++ b/packages/json-schemas/schemas/template/action/repeat.json
@@ -5,6 +5,9 @@
   "description": "Repeats one or more actions while the condition evaluates to true.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/replace-file-content.json
+++ b/packages/json-schemas/schemas/template/action/replace-file-content.json
@@ -5,6 +5,9 @@
   "description": "Replaces content in one or more files using regular expression patterns.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/run.json
+++ b/packages/json-schemas/schemas/template/action/run.json
@@ -5,6 +5,9 @@
   "description": "Executes one or more actions.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/start-server.json
+++ b/packages/json-schemas/schemas/template/action/start-server.json
@@ -5,6 +5,9 @@
   "description": "Starts the project's development server or detects if it's already running.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/stop-server.json
+++ b/packages/json-schemas/schemas/template/action/stop-server.json
@@ -5,6 +5,9 @@
   "description": "Stops the project's development server if it was started by the current process.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/test.json
+++ b/packages/json-schemas/schemas/template/action/test.json
@@ -5,6 +5,9 @@
   "description": "Executes one or more actions depending on the result of a boolean condition.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/schemas/template/action/try.json
+++ b/packages/json-schemas/schemas/template/action/try.json
@@ -5,6 +5,9 @@
   "description": "Attempts to run an action or list of actions and optionally handles errors or cleanup.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The name of the action.",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action.json
@@ -1,9 +1,9 @@
 {
-  "schema": "template/action/change-directory.json",
+  "schema": "template/action.json",
   "input": {
     "$schema": "https://schema.croct.com/json/template/action.json",
-    "name": "change-directory",
-    "path": "."
+    "name": "print",
+    "message": "Hello, world!"
   },
   "errors": []
 }

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/add-component-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/add-component-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/add-component.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "add-component",
     "components": [
       "button",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/add-dependency-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/add-dependency-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/add-dependency.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "add-dependency",
     "dependencies": [
       "croct",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/add-slot-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/add-slot-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/add-slot.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "add-slot",
     "slots": [
       "home-hero",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/check-dependency-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/check-dependency-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/check-dependency.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "check-dependency",
     "dependencies": [
       {

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/create-resource-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/create-resource-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/create-resource.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "create-resource",
     "resources": {
       "audiences": {

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/define-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/define-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/define.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "define",
     "variables": {
       "number": 1,

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/download-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/download-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/download.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "download",
     "source": "github.com/user/repo",
     "destination": "/path/to/destination",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/execute-package-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/execute-package-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/execute-package.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "execute-package",
     "package": "create-react-app",
     "runner": "npm",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/fail-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/fail-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/fail.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "fail",
     "title": "Missing configuration",
     "message": "The project is missing a valid configuration file.",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/format-code-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/format-code-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/format-code.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "format-code",
     "files": ["index.js"]
   },

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/import-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/import-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/import.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "import",
     "template": "croct://template-name",
     "options": {

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/initialize-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/initialize-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/initialize.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "initialize"
   },
   "errors": [

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/locate-file-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/locate-file-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/locate-file.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "locate-file",
     "path": "src",
     "limit": 5,

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/open-link-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/open-link-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/open-link.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "open-link",
     "url": "https://croct.com"
   },

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/print-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/print-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/print.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "print",
     "semantics": "success",
     "message": "Hello world!"

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-choice-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-choice-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/prompt.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "prompt",
     "type": "choice",
     "message": "Select a plan:",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-confirmation-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-confirmation-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/prompt.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "prompt",
     "type": "confirmation",
     "message": "Proceed?",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-keypress-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-keypress-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/prompt.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "prompt",
     "type": "keypress",
     "message": "Press enter to continue:",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-multi-choice-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-multi-choice-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/prompt.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "prompt",
     "type": "multi-choice",
     "message": "Select your interests:",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-text-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/prompt-text-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/prompt.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "prompt",
     "type": "text",
     "message": "Enter your name:",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/repeat-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/repeat-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/repeat.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "repeat",
     "condition": "${this.retryCount < 3}",
     "actions": {

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/replace-file-content-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/replace-file-content-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/replace-file-content.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "replace-file-content",
     "files": [
       {

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/run-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/run-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/run.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "run",
     "actions": {
       "name": "print",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/start-server-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/start-server-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/start-server.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "start-server",
     "result": {
       "url": "serverUrl",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/test-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/test-complete.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/test.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "test",
     "condition":"${this.condition}",
     "then": {

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/try-complete-action-list.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/try-complete-action-list.json
@@ -1,6 +1,7 @@
 {
   "schema": "template/action/try.json",
   "input": {
+    "$schema": "https://schema.croct.com/json/template/action.json",
     "name": "try",
     "action": [
       {

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/template-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/template-complete.json
@@ -212,6 +212,17 @@
           "name": "print",
           "message": "Condition is true"
         }
+      },
+      {
+        "name": "try",
+        "action": {
+          "name": "print",
+          "message": "Trying..."
+        },
+        "finally": {
+          "name": "print",
+          "message": "Done"
+        }
       }
     ]
   },


### PR DESCRIPTION
## Summary

This PR introduces a standalone action schema that can be used in non-validated contexts, such as templates that accept actions as parameters. For example:

```json5
{
  "name": "import",
  "options": {
    "action": {
      "$schema": "https://schema.croct.com/json/v1/action.json",
      "name": "create-resource",
      "resources": {
        // ...
      }
    }
  }
}
```

It also fixes a bug where the `try` template was missing from the list of available actions.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings