### PR TITLE
Correct type for experiment variant allocation field

### DIFF
--- a/packages/json-schemas/schemas/template/action/create-resource.json
+++ b/packages/json-schemas/schemas/template/action/create-resource.json
@@ -265,7 +265,6 @@
                         "allocation": {
                           "type": "integer",
                           "minimum": 0,
-                          "maximum": 1000,
                           "description": "The percentage of traffic to allocate to the variant, where 1000 means 100%."
                         }
                       },

--- a/packages/json-schemas/schemas/template/action/create-resource.json
+++ b/packages/json-schemas/schemas/template/action/create-resource.json
@@ -263,10 +263,10 @@
                           "default": false
                         },
                         "allocation": {
-                          "type": "number",
+                          "type": "integer",
                           "minimum": 0,
-                          "maximum": 1,
-                          "description": "The percentage of traffic to allocate to the variant, where 1 means 100%."
+                          "maximum": 1000,
+                          "description": "The percentage of traffic to allocate to the variant, where 1000 means 100%."
                         }
                       },
                       "required": [

--- a/packages/json-schemas/schemas/template/action/create-resource.json
+++ b/packages/json-schemas/schemas/template/action/create-resource.json
@@ -266,9 +266,9 @@
                           "default": false
                         },
                         "allocation": {
-                          "type": "integer",
+                          "type": "number",
                           "minimum": 0,
-                          "description": "The percentage of traffic to allocate to the variant, where 1000 means 100%."
+                          "description": "Relative traffic ratio between variants. For example, 2 and 1 gives one variant twice the traffic of the other."
                         }
                       },
                       "required": [

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/action/create-resource-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/action/create-resource-complete.json
@@ -125,7 +125,7 @@
             "variants": [
               {
                 "name": "Variant A",
-                "allocation": 0.5,
+                "allocation": 500,
                 "baseline": true,
                 "content": {
                   "default": {
@@ -195,7 +195,7 @@
               },
               {
                 "name": "Variant B",
-                "allocation": 0.5,
+                "allocation": 500,
                 "content": {
                   "default": {
                     "home-hero": {


### PR DESCRIPTION
## Summary

This PR will correct the `allocation` field type since the admin API requires it to be an integer between 0 and 1000.

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings