### PR TITLE
Fix try schema

### DIFF
--- a/packages/json-schemas/schemas/template/action/try.json
+++ b/packages/json-schemas/schemas/template/action/try.json
@@ -46,38 +46,35 @@
           "minItems": 1
         }
       ]
+    },
+    "help": {
+      "description": "Help message to display if the action fails.",
+      "type": "object",
+      "$ref": "https://schema.croct.com/json/template/help.json",
+      "unevaluatedProperties": false
+    },
+    "else": {
+      "description": "Fallback actions to run if the primary action fails.",
+      "oneOf": [
+        {
+          "type": "object",
+          "$ref": "https://schema.croct.com/json/template/action.json"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "https://schema.croct.com/json/template/action.json"
+          },
+          "minItems": 1
+        }
+      ]
     }
   },
-  "anyOf": [
+  "allOf": [
     {
-      "properties": {
-        "else": {
-          "description": "Fallback actions to run if the primary action fails.",
-          "oneOf": [
-            {
-              "type": "object",
-              "$ref": "https://schema.croct.com/json/template/action.json"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "$ref": "https://schema.croct.com/json/template/action.json"
-              },
-              "minItems": 1
-            }
-          ]
-        }
-      }
-    },
-    {
-      "properties": {
-        "help": {
-          "description": "Help message to display if the action fails.",
-          "type": "object",
-          "$ref": "https://schema.croct.com/json/template/help.json",
-          "unevaluatedProperties": false
-        }
+      "not": {
+        "required": ["help", "else"]
       }
     }
   ],
@@ -108,7 +105,9 @@
             "url": "https://docs.example.com"
           }
         ],
-        "suggestions": ["Run `npm install`"]
+        "suggestions": [
+          "Run `npm install`"
+        ]
       }
     }
   ]

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/action/repeat-empty-action-list.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/action/repeat-empty-action-list.json
@@ -27,6 +27,13 @@
     },
     {
       "instancePath": "/actions",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    },
+    {
+      "instancePath": "/actions",
       "keyword": "minItems",
       "message": "must NOT have fewer than 1 items",
       "params": {

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/action/repeat-invalid-property-values.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/action/repeat-invalid-property-values.json
@@ -46,6 +46,13 @@
     },
     {
       "instancePath": "/actions",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    },
+    {
+      "instancePath": "/actions",
       "keyword": "minItems",
       "message": "must NOT have fewer than 1 items",
       "params": {

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/action/run-empty-action-list.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/action/run-empty-action-list.json
@@ -26,6 +26,13 @@
     },
     {
       "instancePath": "/actions",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    },
+    {
+      "instancePath": "/actions",
       "keyword": "minItems",
       "message": "must NOT have fewer than 1 items",
       "params": {

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/action/run-invalid-property-values.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/action/run-invalid-property-values.json
@@ -35,6 +35,13 @@
     },
     {
       "instancePath": "/actions",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    },
+    {
+      "instancePath": "/actions",
       "keyword": "minItems",
       "message": "must NOT have fewer than 1 items",
       "params": {

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/action/test-empty-action-list.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/action/test-empty-action-list.json
@@ -28,6 +28,13 @@
     },
     {
       "instancePath": "/then",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    },
+    {
+      "instancePath": "/then",
       "keyword": "minItems",
       "message": "must NOT have fewer than 1 items",
       "params": {
@@ -52,6 +59,13 @@
         "passingSchemas": null
       },
       "schemaPath": "#/oneOf"
+    },
+    {
+      "instancePath": "/else",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
     },
     {
       "instancePath": "/else",

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/action/test-invalid-property-values.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/action/test-invalid-property-values.json
@@ -47,6 +47,13 @@
     },
     {
       "instancePath": "/then",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    },
+    {
+      "instancePath": "/then",
       "keyword": "minItems",
       "message": "must NOT have fewer than 1 items",
       "params": {
@@ -71,6 +78,13 @@
         "passingSchemas": null
       },
       "schemaPath": "#/oneOf"
+    },
+    {
+      "instancePath": "/else",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
     },
     {
       "instancePath": "/else",

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/action/try-else-help.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/action/try-else-help.json
@@ -1,0 +1,27 @@
+{
+  "schema": "template/action/try.json",
+  "allErrors": true,
+  "input": {
+    "name": "try",
+    "action": {
+      "name": "print",
+      "message": "then"
+    },
+    "else": {
+      "name": "print",
+      "message": "else"
+    },
+    "help": {
+      "message": "Help"
+    }
+  },
+  "errors": [
+    {
+      "instancePath": "",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    }
+  ]
+}

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/action/try-empty-lists.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/action/try-empty-lists.json
@@ -28,6 +28,13 @@
     },
     {
       "instancePath": "/action",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    },
+    {
+      "instancePath": "/action",
       "keyword": "minItems",
       "message": "must NOT have fewer than 1 items",
       "params": {
@@ -55,6 +62,13 @@
     },
     {
       "instancePath": "/finally",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    },
+    {
+      "instancePath": "/finally",
       "keyword": "minItems",
       "message": "must NOT have fewer than 1 items",
       "params": {
@@ -63,13 +77,38 @@
       "schemaPath": "#/properties/finally/oneOf/1/minItems"
     },
     {
-      "instancePath": "",
-      "keyword": "unevaluatedProperties",
-      "message": "must NOT have unevaluated properties",
+      "instancePath": "/else",
+      "keyword": "type",
+      "message": "must be object",
       "params": {
-        "unevaluatedProperty": "else"
+        "type": "object"
       },
-      "schemaPath": "#/unevaluatedProperties"
+      "schemaPath": "#/properties/else/oneOf/0/type"
+    },
+    {
+      "instancePath": "/else",
+      "keyword": "oneOf",
+      "message": "must match exactly one schema in oneOf",
+      "params": {
+        "passingSchemas": null
+      },
+      "schemaPath": "#/oneOf"
+    },
+    {
+      "instancePath": "/else",
+      "keyword": "not",
+      "message": "must NOT be valid",
+      "params": {},
+      "schemaPath": "#/allOf/0/not"
+    },
+    {
+      "instancePath": "/else",
+      "keyword": "minItems",
+      "message": "must NOT have fewer than 1 items",
+      "params": {
+        "limit": 1
+      },
+      "schemaPath": "#/properties/else/oneOf/1/minItems"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fix the `try` schema to make `else` and `help` mutually exclusive.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings