### PR TITLE
Change documentation metadata to be a URL

### DIFF
--- a/packages/json-schemas/schemas/template/catalog-template.json
+++ b/packages/json-schemas/schemas/template/catalog-template.json
@@ -19,9 +19,11 @@
           "type": "boolean",
           "description": "Whether the template is verified by Croct."
         },
-        "documentation": {
+        "documentationUrl": {
           "type": "string",
-          "description": "The template documentation in markdown format.",
+          "description": "The URL of the documentation.",
+          "format": "uri",
+          "pattern": "^https://",
           "minLength": 1
         },
         "sourceUrl": {
@@ -125,7 +127,7 @@
         "coverImageUrl",
         "installationUrl",
         "categories",
-        "documentation"
+        "documentationUrl"
       ],
       "additionalProperties": false
     }

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/catalog-template-empty-metadata.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/catalog-template-empty-metadata.json
@@ -74,9 +74,9 @@
     {
       "instancePath": "/metadata",
       "keyword": "required",
-      "message": "must have required property 'documentation'",
+      "message": "must have required property 'documentationUrl'",
       "params": {
-        "missingProperty": "documentation"
+        "missingProperty": "documentationUrl"
       },
       "schemaPath": "#/properties/metadata/required"
     }

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/catalog-template-extra-property.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/catalog-template-extra-property.json
@@ -20,7 +20,7 @@
       "coverImageUrl": "https://cdn.croct.com/image.png",
       "coverVideoUrl": "https://cdn.croct.com/video.mp4",
       "installationUrl": "shadcn://ui/component",
-      "documentation": "A documentation in markdown format.",
+      "documentationUrl": "A documentation in markdown format.",
       "extra": true
     },
     "actions": [
@@ -51,6 +51,24 @@
         "pattern": "^[a-z0-9-]+/[a-z0-9-]+/[a-z0-9-]+$"
       },
       "schemaPath": "#/properties/metadata/properties/id/pattern"
+    },
+    {
+      "instancePath": "/metadata/documentationUrl",
+      "keyword": "pattern",
+      "message": "must match pattern \"^https://\"",
+      "params": {
+        "pattern": "^https://"
+      },
+      "schemaPath": "#/properties/metadata/properties/documentationUrl/pattern"
+    },
+    {
+      "instancePath": "/metadata/documentationUrl",
+      "keyword": "format",
+      "message": "must match format \"uri\"",
+      "params": {
+        "format": "uri"
+      },
+      "schemaPath": "#/properties/metadata/properties/documentationUrl/format"
     },
     {
       "instancePath": "/metadata/categories/0",

--- a/packages/json-schemas/test/schemas/fixtures/template/invalid/catalog-template-metadata-invalid-property-values.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/invalid/catalog-template-metadata-invalid-property-values.json
@@ -18,7 +18,7 @@
       "coverImageUrl": "",
       "coverVideoUrl": "",
       "installationUrl": "",
-      "documentation": ""
+      "documentationUrl": ""
     }
   },
   "errors": [
@@ -41,13 +41,31 @@
       "schemaPath": "#/properties/metadata/properties/id/pattern"
     },
     {
-      "instancePath": "/metadata/documentation",
+      "instancePath": "/metadata/documentationUrl",
       "keyword": "minLength",
       "message": "must NOT have fewer than 1 characters",
       "params": {
         "limit": 1
       },
-      "schemaPath": "#/properties/metadata/properties/documentation/minLength"
+      "schemaPath": "#/properties/metadata/properties/documentationUrl/minLength"
+    },
+    {
+      "instancePath": "/metadata/documentationUrl",
+      "keyword": "pattern",
+      "message": "must match pattern \"^https://\"",
+      "params": {
+        "pattern": "^https://"
+      },
+      "schemaPath": "#/properties/metadata/properties/documentationUrl/pattern"
+    },
+    {
+      "instancePath": "/metadata/documentationUrl",
+      "keyword": "format",
+      "message": "must match format \"uri\"",
+      "params": {
+        "format": "uri"
+      },
+      "schemaPath": "#/properties/metadata/properties/documentationUrl/format"
     },
     {
       "instancePath": "/metadata/sourceUrl",

--- a/packages/json-schemas/test/schemas/fixtures/template/valid/catalog-template-complete.json
+++ b/packages/json-schemas/test/schemas/fixtures/template/valid/catalog-template-complete.json
@@ -20,7 +20,7 @@
       "coverImageUrl": "https://cdn.croct.com/image.png",
       "coverVideoUrl": "https://cdn.croct.com/video.mp4",
       "installationUrl": "shadcn://ui/component",
-      "documentation": "A documentation in markdown format."
+      "documentationUrl": "https://docs.croct.com"
     },
     "options": {
       "string": {


### PR DESCRIPTION
## Summary
Change documentation metadata to be a URL.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings